### PR TITLE
Support compilation on non-Win32 builds

### DIFF
--- a/Code/Client/NetImgui_Api.h
+++ b/Code/Client/NetImgui_Api.h
@@ -37,7 +37,11 @@
 //			If enabled, then 'ws2_32.lib' library need to be included in project input
 //=================================================================================================
 #ifndef NETIMGUI_WINSOCKET_ENABLED
-#define NETIMGUI_WINSOCKET_ENABLED	(_WIN32 && 1)
+#ifdef _WIN32
+#define NETIMGUI_WINSOCKET_ENABLED	1
+#else
+#define NETIMGUI_WINSOCKET_ENABLED	0
+#endif
 #endif
 
 //=================================================================================================

--- a/Code/Client/Private/NetImgui_Api.cpp
+++ b/Code/Client/Private/NetImgui_Api.cpp
@@ -36,7 +36,8 @@ bool Connect(StartThreadFunctPtr startThreadFunction, const char* clientName, co
 	while( client.mbDisconnectRequest )
 		std::this_thread::sleep_for(std::chrono::milliseconds(8));
 
-	strcpy_s(client.mName, clientName);
+	strncpy(client.mName, clientName, sizeof(client.mName) - 1);
+ 	client.mName[sizeof(client.mName) - 1] = 0;
 	client.mpSocket			= Network::Connect(ServerHost, serverPort);
 	client.mbReuseLocalTime = bReuseLocalTime;
 	if( client.mpSocket )

--- a/Code/Client/Private/NetImgui_Client.cpp
+++ b/Code/Client/Private/NetImgui_Client.cpp
@@ -26,7 +26,8 @@ bool Communications_Initialize(ClientInfo& client)
 {
 	CmdVersion cmdVersionSend;
 	CmdVersion cmdVersionRcv;	
-	strcpy_s(cmdVersionSend.mClientName, client.mName);
+	strncpy(cmdVersionSend.mClientName, client.mName, sizeof(cmdVersionSend.mClientName) - 1);
+	cmdVersionSend.mClientName[sizeof(cmdVersionSend.mClientName) - 1] = 0;
 	bool bResultSend =		Network::DataSend(client.mpSocket, &cmdVersionSend, cmdVersionSend.mHeader.mSize);
 	bool bResultRcv	=		Network::DataReceive(client.mpSocket, &cmdVersionRcv, sizeof(cmdVersionRcv));		
 	client.mbConnected =	bResultRcv && bResultSend && 


### PR DESCRIPTION
Compilation is failing when using Clang on Windows to target an Android device. Fix this by adjusting a macro and switching from strcpy_s to strncpy (which is more widely supported).