### PR TITLE
Add Unix networking

### DIFF
--- a/Code/Client/NetImgui_Api.h
+++ b/Code/Client/NetImgui_Api.h
@@ -30,16 +30,21 @@
 #endif
 
 //=================================================================================================
-// Enable default Win32 networking code
-// Note:	Useful to turn off and implement your own implementation. 
-//			If disabled, then functions implementng 'NetImgui_Network.h' need to be provided
-//			If enabled, then 'ws2_32.lib' library need to be included in project input
+// Enable default Win32/Posix networking code
+// Node:	By default, netImgui uses Winsock on Windows and Posix sockets on non-Windows
+//		platforms. On Windows, make sure you link with 'ws2_32.lib' in your project.
+//
+//		Turn off NETIMGUI_WINSOCKET_ENABLED and NETIMGUI_POSIX_SOCKETS_ENABLED to add your
+//		own implementation. If you do this, you'll have to provide your own implementations
+//		for the functions in 'NetImgui_Network.h'.
 //=================================================================================================
 #ifndef NETIMGUI_WINSOCKET_ENABLED
 #ifdef _WIN32
 #define NETIMGUI_WINSOCKET_ENABLED	1
+#define NETIMGUI_POSIX_SOCKETS_ENABLED	0
 #else
 #define NETIMGUI_WINSOCKET_ENABLED	0
+#define NETIMGUI_POSIX_SOCKETS_ENABLED	1
 #endif
 #endif
 

--- a/Code/Client/Private/NetImgui_NetworkPosix.cpp
+++ b/Code/Client/Private/NetImgui_NetworkPosix.cpp
@@ -1,6 +1,6 @@
 #include "NetImgui_Shared.h"
 
-#if NETIMGUI_ENABLED && !NETIMGUI_WINSOCKET_ENABLED
+#if NETIMGUI_ENABLED && NETIMGUI_POSIX_SOCKETS_ENABLED
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
@@ -68,5 +68,5 @@ bool DataSend(SocketInfo* pClientSocket, void* pDataOut, size_t Size)
 
 }}} // namespace NetImgui::Internal::Network
 
-#endif // #if NETIMGUI_ENABLED && !NETIMGUI_WINSOCKET_ENABLED
+#endif // #if NETIMGUI_ENABLED && NETIMGUI_POSIX_SOCKETS_ENABLED
 

--- a/Code/Client/Private/NetImgui_NetworkUnix.cpp
+++ b/Code/Client/Private/NetImgui_NetworkUnix.cpp
@@ -1,0 +1,72 @@
+#include "NetImgui_Shared.h"
+
+#if NETIMGUI_ENABLED && !NETIMGUI_WINSOCKET_ENABLED
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+
+namespace NetImgui { namespace Internal { namespace Network 
+{
+
+struct SocketInfo
+{
+	SocketInfo(int socket) : mSocket(socket){}
+	int mSocket;
+};
+
+bool Startup()
+{
+	return true;
+}
+
+void Shutdown()
+{
+}
+
+SocketInfo* Connect(const char* ServerHost, uint32_t ServerPort)
+{
+	int ConnectSocket = socket(AF_INET , SOCK_STREAM , 0 );
+	if(ConnectSocket == -1)
+		return nullptr;
+	
+	char zPortName[32];
+	addrinfo* pResults(nullptr);
+	sprintf(zPortName, "%i", ServerPort);
+	getaddrinfo(ServerHost, zPortName, nullptr, &pResults);
+	while( pResults )
+	{
+		if( connect(ConnectSocket, pResults->ai_addr, static_cast<int>(pResults->ai_addrlen)) == 0 )
+			return netImguiNew<SocketInfo>(ConnectSocket);
+				
+		pResults = pResults->ai_next;
+	}
+		
+	return nullptr;
+}
+
+void Disconnect(SocketInfo* pClientSocket)
+{
+	if( pClientSocket )
+	{
+		close(pClientSocket->mSocket);
+		netImguiDelete(pClientSocket);
+	}
+}
+
+bool DataReceive(SocketInfo* pClientSocket, void* pDataIn, size_t Size)
+{
+	int resultRcv = recv(pClientSocket->mSocket, static_cast<char*>(pDataIn), static_cast<int>(Size), MSG_WAITALL);
+	return resultRcv != -1 && resultRcv > 0;
+}
+
+bool DataSend(SocketInfo* pClientSocket, void* pDataOut, size_t Size)
+{
+	int resultSend = send(pClientSocket->mSocket, static_cast<char*>(pDataOut), static_cast<int>(Size), 0);
+	return resultSend != -1 && resultSend > 0;
+}
+
+}}} // namespace NetImgui::Internal::Network
+
+#endif // #if NETIMGUI_ENABLED && !NETIMGUI_WINSOCKET_ENABLED
+


### PR DESCRIPTION
netImgui so far has support for Win32 networking. This change adds Unix socket support and enables it anytime WIN32 isn't there.

Only tested on Android (Oculus Quest) so far.