### PR TITLE
Make StringCopy work cross platform

### DIFF
--- a/Code/Client/Private/NetImgui_Api.cpp
+++ b/Code/Client/Private/NetImgui_Api.cpp
@@ -39,8 +39,7 @@ bool ConnectToApp(ThreadFunctPtr startThreadFunction, const char* clientName, co
 	while( client.mbDisconnectRequest )
 		std::this_thread::sleep_for(std::chrono::milliseconds(8));
 
-	StringCopy(client.mName, sizeof(client.mName), (clientName == nullptr || clientName[0] == 0 ? "Unnamed" : clientName));
- 	client.mName[sizeof(client.mName)-1]= 0;
+	StringCopy(client.mName, (clientName == nullptr || clientName[0] == 0 ? "Unnamed" : clientName));
 	client.mbReuseLocalTime				= bReuseLocalTime;
 	client.mpSocket						= Network::Connect(ServerHost, serverPort);	
 	client.mbConnectRequest				= client.mpSocket != nullptr;	
@@ -70,8 +69,7 @@ bool ConnectFromApp(ThreadFunctPtr startThreadFunction, const char* clientName, 
 	while (client.mbDisconnectRequest)
 		std::this_thread::sleep_for(std::chrono::milliseconds(8));
 
-	StringCopy(client.mName, sizeof(client.mName), (clientName == nullptr || clientName[0] == 0 ? "Unnamed" : clientName));
-	client.mName[sizeof(client.mName)-1]= 0;
+	StringCopy(client.mName, (clientName == nullptr || clientName[0] == 0 ? "Unnamed" : clientName));
 	client.mbReuseLocalTime				= bReuseLocalTime;	
 	client.mpSocket						= Network::ListenStart(serverPort);
 	client.mbConnectRequest				= client.mpSocket != nullptr;

--- a/Code/Client/Private/NetImgui_Client.cpp
+++ b/Code/Client/Private/NetImgui_Client.cpp
@@ -26,8 +26,7 @@ bool Communications_Initialize(ClientInfo& client)
 {
 	CmdVersion cmdVersionSend;
 	CmdVersion cmdVersionRcv;	
-	StringCopy(cmdVersionSend.mClientName, sizeof(cmdVersionSend.mClientName), client.mName);
-	cmdVersionSend.mClientName[sizeof(cmdVersionSend.mClientName) - 1] = 0;
+	StringCopy(cmdVersionSend.mClientName, client.mName);
 	bool bResultSend =		Network::DataSend(client.mpSocket, &cmdVersionSend, cmdVersionSend.mHeader.mSize);
 	bool bResultRcv	=		Network::DataReceive(client.mpSocket, &cmdVersionRcv, sizeof(cmdVersionRcv));		
 	client.mbConnected =	bResultRcv && bResultSend && 

--- a/Code/Client/Private/NetImgui_Shared.h
+++ b/Code/Client/Private/NetImgui_Shared.h
@@ -121,7 +121,8 @@ constexpr std::size_t ArrayCount(T const (&)[N]) noexcept
 	return N;
 }
 
-inline void StringCopy(char* zDest, size_t destLen, const char* zSource );
+template <size_t charCount>
+inline void StringCopy(char (&output)[charCount], const char* pSrc);
 
 }} //namespace NetImgui::Internal
 

--- a/Code/Client/Private/NetImgui_Shared.inl
+++ b/Code/Client/Private/NetImgui_Shared.inl
@@ -205,13 +205,25 @@ void Ringbuffer<TType,TCount>::ReadData(TType* pData, size_t& count)
 
 //=============================================================================
 //=============================================================================
-void StringCopy(char* zDest, size_t destLen, const char* zSource )
+// The _s string functions are a mess. There's really no way to do this right
+// in a cross-platform way. Best solution I've found is to set just use
+// strncpy, infer the buffer length, and null terminate. Still need to suppress
+// the warning on Windows.
+// See https://randomascii.wordpress.com/2013/04/03/stop-using-strncpy-already/
+// and many other discussions online on the topic.
+template <size_t charCount>
+void StringCopy(char (&output)[charCount], const char* pSrc)
 {
-#if defined (__clang__) || defined(_MSC_VER) 
-	strncpy_s(zDest, destLen, zSource, destLen - 1);
-#else
-	strncpy(zDest, zSource, destLen - 1);
-#endif
+	#if defined(_MSC_VER) 
+	        #pragma warning (push)
+	        #pragma warning (disable: 4996)
+	#endif
+	strncpy(output, pSrc, charCount - 1);
+	#if defined(_MSC_VER) 
+	        #pragma warning (pop)
+	#endif
+
+	output[charCount - 1] = 0;
 }
 
 }} //namespace NetImgui::Internal


### PR DESCRIPTION
The way it was set up was with defines based on compiler type. This didn't work for my use case because the #if in StringCopy() checked for (__clang__ || MSVC). In my use on Android with Clang, the former is defined. I'm guessing that whatever standard library you're using for your target console is also Clang but that version happens to have support for the _s functions, which mine doesn't.

The two options are:
1.) Find the right set of defines to make this work where each platform does its own thing
2.) Turn off the warning for MSVC and just use strncpy

Option 1 suffers from the problem that the code is different between platforms, which is non-optimal. Most sources online (e.g. https://randomascii.wordpress.com/2013/04/03/stop-using-strncpy-already/) just say to disable the warning and make your string copy function work the way you want. So this commit goes with option 2.