### PR TITLE
Fix linux compilation

### DIFF
--- a/Code/Client/Private/NetImgui_Api.cpp
+++ b/Code/Client/Private/NetImgui_Api.cpp
@@ -282,7 +282,7 @@ void SendDataTexture(ImTextureID textureId, void* pData, uint16_t width, uint16_
 
 	// Makes sure even 32bits ImTextureID value are received properly as 64bits
 	uint64_t texId64(0);
-	static_assert(sizeof(uint64_t) <= sizeof(textureId), "ImTextureID is bigger than 64bits, CmdTexture::mTextureId needs to be updated to support it");
+	static_assert(sizeof(uint64_t) >= sizeof(textureId), "ImTextureID is bigger than 64bits, CmdTexture::mTextureId needs to be updated to support it");
 	reinterpret_cast<ImTextureID*>(&texId64)[0] = textureId;
 
 	// Add/Update a texture

--- a/Code/Client/Private/NetImgui_Client.h
+++ b/Code/Client/Private/NetImgui_Client.h
@@ -63,7 +63,7 @@ struct ClientInfo
 	std::atomic<Network::SocketInfo*>	mpSocketPending;						// Hold socket info until communication is established
 	std::atomic<Network::SocketInfo*>	mpSocketComs;							// Socket used for communications with server
 	std::atomic<Network::SocketInfo*>	mpSocketListen;							// Socket used to wait for communication request from server
-	char								mName[64]					={};
+	char								mName[64]					= {};
 	VecTexture							mTextures;
 	CmdTexture*							mTexturesPending[16];
 	ExchangePtr<CmdDrawFrame>			mPendingFrameOut;
@@ -76,9 +76,9 @@ struct ClientInfo
 	ImGuiContext*						mpContext					= nullptr;	// Context that the remote drawing should use (either the one active when connection request happened, or a clone)
 	ImVec2								mSavedDisplaySize			= {0, 0};	// Save original display size on 'NewFrame' and restore it on 'EndFrame' (making sure size is still valid after a disconnect)
 	const void*							mpFontTextureData			= nullptr;	// Last font texture data send to server (used to detect if font was changed)
-	ImTextureID							mFontTextureID				= static_cast<ImTextureID>(0);
+	ImTextureID							mFontTextureID				= reinterpret_cast<ImTextureID>(0);
 	SavedImguiContext					mSavedContextValues;
-	Time								mTimeTracking;							// Used to update Dear ImGui time delta on remote context //SF remove?
+	Time								mTimeTracking;							// Used to update Dear ImGui time delta on remote context
 	std::atomic_uint32_t				mTexturesPendingSent;
 	std::atomic_uint32_t				mTexturesPendingCreated;
 	float								mMouseWheelVertPrev			= 0.f;

--- a/Code/Client/Private/NetImgui_Client.h
+++ b/Code/Client/Private/NetImgui_Client.h
@@ -76,7 +76,7 @@ struct ClientInfo
 	ImGuiContext*						mpContext					= nullptr;	// Context that the remote drawing should use (either the one active when connection request happened, or a clone)
 	ImVec2								mSavedDisplaySize			= {0, 0};	// Save original display size on 'NewFrame' and restore it on 'EndFrame' (making sure size is still valid after a disconnect)
 	const void*							mpFontTextureData			= nullptr;	// Last font texture data send to server (used to detect if font was changed)
-	ImTextureID							mFontTextureID				= reinterpret_cast<ImTextureID>(0);
+	ImTextureID							mFontTextureID				= static_cast<ImTextureID>(0);
 	SavedImguiContext					mSavedContextValues;
 	Time								mTimeTracking;							// Used to update Dear ImGui time delta on remote context
 	std::atomic_uint32_t				mTexturesPendingSent;

--- a/Code/Client/Private/NetImgui_Client.h
+++ b/Code/Client/Private/NetImgui_Client.h
@@ -63,7 +63,7 @@ struct ClientInfo
 	std::atomic<Network::SocketInfo*>	mpSocketPending;						// Hold socket info until communication is established
 	std::atomic<Network::SocketInfo*>	mpSocketComs;							// Socket used for communications with server
 	std::atomic<Network::SocketInfo*>	mpSocketListen;							// Socket used to wait for communication request from server
-	char								mName[64]					= {};
+	char								mName[64]					={};
 	VecTexture							mTextures;
 	CmdTexture*							mTexturesPending[16];
 	ExchangePtr<CmdDrawFrame>			mPendingFrameOut;
@@ -78,7 +78,7 @@ struct ClientInfo
 	const void*							mpFontTextureData			= nullptr;	// Last font texture data send to server (used to detect if font was changed)
 	ImTextureID							mFontTextureID				= static_cast<ImTextureID>(0);
 	SavedImguiContext					mSavedContextValues;
-	Time								mTimeTracking;							// Used to update Dear ImGui time delta on remote context
+	Time								mTimeTracking;							// Used to update Dear ImGui time delta on remote context //SF remove?
 	std::atomic_uint32_t				mTexturesPendingSent;
 	std::atomic_uint32_t				mTexturesPendingCreated;
 	float								mMouseWheelVertPrev			= 0.f;

--- a/Code/Client/Private/NetImgui_CmdPackets_DrawFrame.cpp
+++ b/Code/Client/Private/NetImgui_CmdPackets_DrawFrame.cpp
@@ -64,7 +64,7 @@ inline void ImGui_ExtractDraws(uint32_t& indiceByteOffset, uint32_t& vertexIndex
 		#else
 			pOutDraws[drawIndex].mVtxOffset		= vertexIndex;
 		#endif
-			pOutDraws[drawIndex].mTextureId		= reinterpret_cast<uint64_t>(pCmd->TextureId);
+			pOutDraws[drawIndex].mTextureId		= static_cast<uint64_t>(pCmd->TextureId);
 			pOutDraws[drawIndex].mIdxCount		= pCmd->ElemCount;
 			pOutDraws[drawIndex].mIndexSize		= is16Bit ? 2 : 4;
 			pOutDraws[drawIndex].mClipRect[0]	= pCmd->ClipRect.x;

--- a/Code/Client/Private/NetImgui_CmdPackets_DrawFrame.cpp
+++ b/Code/Client/Private/NetImgui_CmdPackets_DrawFrame.cpp
@@ -64,7 +64,7 @@ inline void ImGui_ExtractDraws(uint32_t& indiceByteOffset, uint32_t& vertexIndex
 		#else
 			pOutDraws[drawIndex].mVtxOffset		= vertexIndex;
 		#endif
-			pOutDraws[drawIndex].mTextureId		= reinterpret_cast<uint64_t>(pCmd->TextureId);
+			pOutDraws[drawIndex].mTextureId		= TextureCastHelper(pCmd->TextureId);
 			pOutDraws[drawIndex].mIdxCount		= pCmd->ElemCount;
 			pOutDraws[drawIndex].mIndexSize		= is16Bit ? 2 : 4;
 			pOutDraws[drawIndex].mClipRect[0]	= pCmd->ClipRect.x;

--- a/Code/Client/Private/NetImgui_CmdPackets_DrawFrame.cpp
+++ b/Code/Client/Private/NetImgui_CmdPackets_DrawFrame.cpp
@@ -64,7 +64,7 @@ inline void ImGui_ExtractDraws(uint32_t& indiceByteOffset, uint32_t& vertexIndex
 		#else
 			pOutDraws[drawIndex].mVtxOffset		= vertexIndex;
 		#endif
-			pOutDraws[drawIndex].mTextureId		= static_cast<uint64_t>(pCmd->TextureId);
+			pOutDraws[drawIndex].mTextureId		= reinterpret_cast<uint64_t>(pCmd->TextureId);
 			pOutDraws[drawIndex].mIdxCount		= pCmd->ElemCount;
 			pOutDraws[drawIndex].mIndexSize		= is16Bit ? 2 : 4;
 			pOutDraws[drawIndex].mClipRect[0]	= pCmd->ClipRect.x;

--- a/Code/Client/Private/NetImgui_NetworkPosix.cpp
+++ b/Code/Client/Private/NetImgui_NetworkPosix.cpp
@@ -9,6 +9,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 namespace NetImgui { namespace Internal { namespace Network 
 {
@@ -81,8 +82,8 @@ SocketInfo* ListenStart(uint32_t ListenPort)
 	if( ListenSocket != -1 )
 	{
 		int flag = 1;  
-		setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
-		setsockopt(sockfd, SOL_SOCKET, SO_REUSEPORT, &flag, sizeof(flag));
+		setsockopt(ListenSocket, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag));
+		setsockopt(ListenSocket, SOL_SOCKET, SO_REUSEPORT, &flag, sizeof(flag));
 		if(	bind(ListenSocket, addrInfo->ai_addr, addrInfo->ai_addrlen) != -1 &&
 			listen(ListenSocket, 0) != -1)
 		{


### PR DESCRIPTION
Hi, while playing with imgui on Linux today I wanted to add netimgui in my project and had to do a couple edits to compile.

First I had to add a missing include and fix what I think is a typo in NetImgui_NetworkPosix.cpp but I also had some issues with ImTexture. I think the condition in the assert is doing the opposite of what the message says and I also had to change some reinterpret_cast to static_cast.

Let me know if you think the reinterpret_cast issue could be from my imgui integration and I'll revert the change.

