### PR TITLE
Skip preamble when parsing command line host;port

### DIFF
--- a/Code/ServerApp/Source/NetImguiServer_App.cpp
+++ b/Code/ServerApp/Source/NetImguiServer_App.cpp
@@ -84,9 +84,10 @@ bool AddClientConfigFromString(const char* string, bool transient)
 	while( *zEntryCur != 0 )
 	{
 		zEntryCur++;
-		if (*zEntryCur == ' ')
+		// Skip commandline preamble holding path to executable
+		if (*zEntryCur == ' ' && *(zEntryCur+1) != 0)
 		{
-			zEntryStart = zEntryCur;
+			zEntryStart = zEntryCur + 1;
 		}
 		if( (*zEntryCur == ';' || *zEntryCur == 0) )
 		{

--- a/Code/ServerApp/Source/NetImguiServer_App.cpp
+++ b/Code/ServerApp/Source/NetImguiServer_App.cpp
@@ -84,6 +84,10 @@ bool AddClientConfigFromString(const char* string, bool transient)
 	while( *zEntryCur != 0 )
 	{
 		zEntryCur++;
+		if (*zEntryCur == ' ')
+		{
+			zEntryStart = zEntryCur;
+		}
 		if( (*zEntryCur == ';' || *zEntryCur == 0) )
 		{
 			if (paramIndex == 0)


### PR DESCRIPTION
There may be a bigger scope fix that would solve this better but the key thing I noticed was that the entire command line was being parsed.

This change resets the "start" point whenever it sees a space.  This assumes that the host and port will never contain spaces nor be separated by spaces.