### PR TITLE
Fix accept thread not getting properly signalled to stop on certain platforms

### DIFF
--- a/Code/Client/Private/NetImgui_NetworkPosix.cpp
+++ b/Code/Client/Private/NetImgui_NetworkPosix.cpp
@@ -115,6 +115,7 @@ void Disconnect(SocketInfo* pClientSocket)
 {
 	if( pClientSocket )
 	{
+		shutdown(pClientSocket->mSocket, SHUT_RDWR);
 		close(pClientSocket->mSocket);
 		netImguiDelete(pClientSocket);
 	}

--- a/Code/Client/Private/NetImgui_NetworkWin32.cpp
+++ b/Code/Client/Private/NetImgui_NetworkWin32.cpp
@@ -116,6 +116,7 @@ void Disconnect(SocketInfo* pClientSocket)
 {
 	if( pClientSocket )
 	{
+		shutdown(pClientSocket->mSocket, SD_BOTH);
 		closesocket(pClientSocket->mSocket);
 		netImguiDelete(pClientSocket);
 	}


### PR DESCRIPTION
To properly signal the blocking thread we need first to call shutdown() before close() on the socket, otherwise you need to signal the thread manually.