### PR TITLE
* Fix server network restart

### DIFF
--- a/Code/ServerApp/Source/NetImguiServer_Network.cpp
+++ b/Code/ServerApp/Source/NetImguiServer_Network.cpp
@@ -368,6 +368,7 @@ bool Startup( )
 		return false;
 	}
 	
+	gbShutdown = false;
 	gActiveClientThreadCount = 0;	
 	std::thread(NetworkConnectRequest_Receive).detach();
 	std::thread(NetworkConnectRequest_Send).detach();


### PR DESCRIPTION
Fix restarting network module in NetImguiServer.
This is necessary for restarting NetImguiServer without restarting whole application.