### PR TITLE
On Mac, make an app bundle rather than a bare executable.

### DIFF
--- a/Build/netImgui.sharpmake.cs
+++ b/Build/netImgui.sharpmake.cs
@@ -89,7 +89,11 @@ namespace NetImgui
 			conf.Options.Add(new Options.Vc.Linker.DisableSpecificWarnings("4099")); //Prevents: warning LNK4099: PDB '' was not found with 'glfw3_mtd.lib(context.c.obj)' or at ''; linking object as if no debug info
 			//---------------------------------------------
 			
-			if (target.DevEnv != DevEnv.xcode4ios)
+			if (target.DevEnv == DevEnv.xcode4ios)
+			{
+				conf.Options.Add(new Sharpmake.Options.XCode.Compiler.InfoPListFile(NetImguiTarget.GetPath(@"/Code/ServerApp/info.plist")));
+			}
+			else
 			{
 				conf.EventPostBuild.Add("xcopy \"" + NetImguiTarget.GetPath(@"\Code\ServerApp\Background.png") + "\" \"" + conf.TargetPath + "\" /D /Y");
 			}

--- a/Build/shared.sharpmake_mac.cs
+++ b/Build/shared.sharpmake_mac.cs
@@ -143,7 +143,7 @@ namespace NetImgui
 			conf.TargetPath			= NetImguiTarget.GetPath( mIsExe	? @"/_Bin/[target.DevEnv]_[target.Compiler]_[target.Platform]" 
 																		: @"\_generated/Libs\[target.DevEnv]_[target.Compiler]_[target.Platform]");
 			conf.IntermediatePath	= NetImguiTarget.GetPath(@"/_intermediate\[target.DevEnv]_[target.Compiler]_[target.Platform]_[target.Optimization]/[project.Name]");
-			conf.Output				= mIsExe ? Project.Configuration.OutputType.Exe : Project.Configuration.OutputType.Lib;
+			conf.Output				= mIsExe ? Project.Configuration.OutputType.IosApp : Project.Configuration.OutputType.Lib;
 			
 			conf.IncludePaths.Add(NetImguiTarget.GetPath(ProjectImgui.sDefaultPath) + @"\backends");
 

--- a/Code/ServerApp/info.plist
+++ b/Code/ServerApp/info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>${EXECUTABLE_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${PRODUCT_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSPrincipalClass</key>
+    <string></string>
+</dict>
+</plist>


### PR DESCRIPTION
- Change the output type for Mac builds to OutputType.IosApp (this enum value is misleading and is renamed in later versions of Sharpmake), which creates a proper app rather than a simple executable. One benefit is that a terminal window is no longer opened when running.
-  Add a minimal info.plist properties file required for this.