### PR TITLE
Simple fixes

### DIFF
--- a/Code/Client/NetImgui_Api.h
+++ b/Code/Client/NetImgui_Api.h
@@ -255,7 +255,18 @@ NETIMGUI_API	eCompressionMode	GetCompressionMode();
 NETIMGUI_API	uint8_t				GetTexture_BitsPerPixel	(eTexFormat eFormat);
 NETIMGUI_API	uint32_t			GetTexture_BytePerLine	(eTexFormat eFormat, uint32_t pixelWidth);
 NETIMGUI_API	uint32_t			GetTexture_BytePerImage	(eTexFormat eFormat, uint32_t pixelWidth, uint32_t pixelHeight);
-} 
+
+} // namespace NetImgui
+
+//=================================================================================================
+// Texture Cast Helper functions (not part of the API per se, but useful for user code)
+// Note: ImTextureID could be anything (void *, uint64_t, uint_16t, GLuint, etc.)
+//       so that using reinterpret_cast / static_cast can generate warnings or errors in some compilers,
+//       so we resort to a C style double cast.
+//=================================================================================================
+inline ImTextureID ToImTextureID(void* pTexture) { return (ImTextureID)(intptr_t)pTexture; }
+inline ImTextureID ToImTextureID(uint64_t texture) { return (ImTextureID)(intptr_t)texture; }
+
 
 //=================================================================================================
 // Optional single include compiling option

--- a/Code/Client/Private/NetImgui_Api.cpp
+++ b/Code/Client/Private/NetImgui_Api.cpp
@@ -724,7 +724,7 @@ bool ProcessInputData(Client::ClientInfo& client)
 			}
 		}
 #endif
-		uint16_t character;
+		ImWchar character;
 		io.InputQueueCharacters.resize(0);
 		while (client.mPendingKeyIn.ReadData(&character)){
 			io.AddInputCharacter(character);

--- a/Code/Client/Private/NetImgui_Api.cpp
+++ b/Code/Client/Private/NetImgui_Api.cpp
@@ -153,7 +153,10 @@ bool NewFrame(bool bSupportFrameSkip)
 
 	Client::ClientInfo& client = *gpClientInfo;	
 	ScopedBool scopedInside(client.mbInsideNewEnd, true);
-	assert(!client.mbIsDrawing);
+
+	//assert(!client.mbIsDrawing);
+    if (client.mbIsDrawing)
+        return false;
 
 	// ImGui Newframe handled by remote connection settings
 	if( NetImgui::IsConnected() )

--- a/Code/Client/Private/NetImgui_Client.h
+++ b/Code/Client/Private/NetImgui_Client.h
@@ -53,7 +53,7 @@ struct SavedImguiContext
 struct ClientInfo
 {
 	using VecTexture	= ImVector<ClientTexture>;
-	using BufferKeys	= Ringbuffer<uint16_t, 1024>;
+	using BufferKeys	= Ringbuffer<ImWchar, 1024>;
 	using Time			= std::chrono::time_point<std::chrono::high_resolution_clock>;
 
 	struct InputState

--- a/Code/Client/Private/NetImgui_NetworkPosix.cpp
+++ b/Code/Client/Private/NetImgui_NetworkPosix.cpp
@@ -10,6 +10,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <string>
 
 namespace NetImgui { namespace Internal { namespace Network 
 {

--- a/Code/Sample/SampleBackground/SampleBackground.cpp
+++ b/Code/Sample/SampleBackground/SampleBackground.cpp
@@ -59,7 +59,7 @@ bool SampleBackground::Startup()
 		}
 	}
 	TextureCreate(reinterpret_cast<uint8_t*>(pixels), kSize, kSize, mTextureView);													// For local display
-	NetImgui::SendDataTexture(static_cast<ImTextureID>(mTextureView), pixels, kSize, kSize, NetImgui::eTexFormat::kTexFmtRGBA8);	// For remote display
+	NetImgui::SendDataTexture(ToImTextureID(mTextureView), pixels, kSize, kSize, NetImgui::eTexFormat::kTexFmtRGBA8);	// For remote display
 	return true;
 }
 
@@ -99,13 +99,13 @@ ImDrawData* SampleBackground::Draw()
 			ImGui::ColorEdit4("Background", reinterpret_cast<float*>(&sBgColor), ImGuiColorEditFlags_Float | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_PickerHueWheel);
 			ImGui::ColorEdit4("Logo Tint", reinterpret_cast<float*>(&sTextureTint), ImGuiColorEditFlags_Float | ImGuiColorEditFlags_DisplayRGB | ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_PickerHueWheel);			
 			ImGui::Checkbox("Replace Background Texture", &sUseTextureOverride);
-			ImGui::Image(mTextureView, ImVec2(64,64));
+			ImGui::Image(ToImTextureID(mTextureView), ImVec2(64, 64));
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.f));
 			ImGui::TextWrapped("(Note: Custom background settings only applied on remote server)");
 			ImGui::PopStyleColor();
 			if( sUseTextureOverride )
 			{
-				NetImgui::SetBackground(sBgColor, sTextureTint, static_cast<ImTextureID>(mTextureView));
+				NetImgui::SetBackground(sBgColor, sTextureTint, ToImTextureID(mTextureView));
 			}
 			else
 			{ 

--- a/Code/Sample/SampleBackground/SampleBackground.cpp
+++ b/Code/Sample/SampleBackground/SampleBackground.cpp
@@ -6,6 +6,7 @@
 
 #include <NetImgui_Api.h>
 #include <array>
+#include <cmath>
 #include "../Common/Sample.h"
 
 // Methods declared in main.cpp, extern declare to avoid having to include 'd3d11.h' here

--- a/Code/Sample/SampleTextures/SampleTextures.cpp
+++ b/Code/Sample/SampleTextures/SampleTextures.cpp
@@ -88,7 +88,7 @@ void SampleTextures::TextureFormatCreation(NetImgui::eTexFormat eTexFmt)
 		constexpr uint32_t Height		= 8;
 		uint8_t pixelData[Width * Height * 4]={};
 		TextureCreate(pixelData, Width, Height, mCustomTextureView[static_cast<int>(eTexFmt)]);	// For local display
-		NetImgui::SendDataTexture(static_cast<ImTextureID>(mCustomTextureView[static_cast<int>(eTexFmt)]), &customTextrueData, Width, Height, eTexFmt, sizeof(customTextureData1));	// For remote display
+		NetImgui::SendDataTexture(ToImTextureID(mCustomTextureView[static_cast<int>(eTexFmt)]), &customTextrueData, Width, Height, eTexFmt, sizeof(customTextureData1));	// For remote display
 	}
 	else
 #endif
@@ -125,7 +125,7 @@ void SampleTextures::TextureFormatCreation(NetImgui::eTexFormat eTexFmt)
 		case NetImgui::eTexFormat::kTexFmt_Invalid: assert(0); break;
 		}
 		TextureCreate(pixelData, Width, Height, mCustomTextureView[static_cast<int>(eTexFmt)]);													// For local display
-		NetImgui::SendDataTexture(static_cast<ImTextureID>(mCustomTextureView[static_cast<int>(eTexFmt)]), pixelData, Width, Height, eTexFmt);	// For remote display
+		NetImgui::SendDataTexture(ToImTextureID(mCustomTextureView[static_cast<int>(eTexFmt)]), pixelData, Width, Height, eTexFmt);	// For remote display
 	}
 }
 
@@ -137,7 +137,7 @@ void SampleTextures::TextureFormatDestruction(NetImgui::eTexFormat eTexFmt)
 	if (mCustomTextureView[static_cast<int>(eTexFmt)])
 	{
 		// Remove texture from the remote client (on NetImgui Server)
-		NetImgui::SendDataTexture(static_cast<ImTextureID>(mCustomTextureView[static_cast<int>(eTexFmt)]), nullptr, 0, 0, NetImgui::eTexFormat::kTexFmt_Invalid);
+		NetImgui::SendDataTexture(ToImTextureID(mCustomTextureView[static_cast<int>(eTexFmt)]), nullptr, 0, 0, NetImgui::eTexFormat::kTexFmt_Invalid);
 		
 		// Remove texture created locally (in this sample application)
 		TextureDestroy(mCustomTextureView[static_cast<int>(eTexFmt)]);
@@ -156,7 +156,7 @@ bool SampleTextures::Startup()
 	pixelData.fill(0);
 
 	TextureCreate(pixelData.data(), 8, 8, mDefaultEmptyTexture);
-	NetImgui::SendDataTexture(static_cast<ImTextureID>(mDefaultEmptyTexture), pixelData.data(), 8, 8, NetImgui::eTexFormat::kTexFmtRGBA8);
+	NetImgui::SendDataTexture(ToImTextureID(mDefaultEmptyTexture), pixelData.data(), 8, 8, NetImgui::eTexFormat::kTexFmtRGBA8);
 
 	return true;
 }
@@ -166,7 +166,7 @@ bool SampleTextures::Startup()
 //=================================================================================================
 void SampleTextures::Shutdown()
 {
-	NetImgui::SendDataTexture(static_cast<ImTextureID>(mDefaultEmptyTexture), nullptr, 0, 0, NetImgui::eTexFormat::kTexFmt_Invalid);
+	NetImgui::SendDataTexture(ToImTextureID(mDefaultEmptyTexture), nullptr, 0, 0, NetImgui::eTexFormat::kTexFmt_Invalid);
 	TextureDestroy(mDefaultEmptyTexture);
 	SampleClient_Base::Shutdown();
 }
@@ -231,11 +231,11 @@ ImDrawData* SampleTextures::Draw()
 			#if TEXTURE_CUSTOM_SAMPLE
 				customTextureData2 customTextureData;
 				customTextureData.m_TimeUS = static_cast<uint64_t>(ImGui::GetTime() * 1000.f * 1000.f);
-				NetImgui::SendDataTexture(reinterpret_cast<ImTextureID>(0x02020202), &customTextureData, 128, 64, NetImgui::eTexFormat::kTexFmtCustom, sizeof(customTextureData));
+				NetImgui::SendDataTexture(ToImTextureID((void *) 0x02020202), &customTextureData, 128, 64, NetImgui::eTexFormat::kTexFmtCustom, sizeof(customTextureData));
 
 				ImGui::NewLine();
 				ImGui::TextUnformatted("Custom Texture");
-				ImGui::Image(reinterpret_cast<ImTextureID>(0x02020202), ImVec2(128, 64), ImVec2(0, 0), ImVec2(1, 1), tint_col, border_col);
+				ImGui::Image(ToImTextureID((void *) 0x02020202), ImVec2(128, 64), ImVec2(0, 0), ImVec2(1, 1), tint_col, border_col);
 				ImGui::SameLine();
 				ImGui::TextWrapped("Server regenerate this texture every frame using a custom texture update and a time parameter. This behavior is custom implemented by library user on both the Client and Server codebase.");
 			#endif
@@ -243,7 +243,7 @@ ImDrawData* SampleTextures::Draw()
 
 				ImGui::NewLine();
 				ImGui::TextUnformatted("Invalid Texture");
-				ImGui::Image(reinterpret_cast<ImTextureID>(0x01010101), ImVec2(128, 64), ImVec2(0, 0), ImVec2(1, 1), tint_col, border_col);
+				ImGui::Image(ToImTextureID((void *) 0x01010101), ImVec2(128, 64), ImVec2(0, 0), ImVec2(1, 1), tint_col, border_col);
 				ImGui::SameLine();
 				ImGui::TextWrapped("Invalid textures handled by netImgui server by using a default invisible texture.");
 		

--- a/Code/ServerApp/Source/NetImguiServer_Network.cpp
+++ b/Code/ServerApp/Source/NetImguiServer_Network.cpp
@@ -304,7 +304,7 @@ void NetworkConnectRequest_Receive()
 		{
 			serverPort		= NetImguiServer::Config::Server::sPort;
 			gListenSocket	= NetImgui::Internal::Network::ListenStart(serverPort);
-			if( gListenSocket.load() != nullptr )
+			if( gListenSocket.load() == nullptr )
 			{
 				printf("Failed to start connection listen on port : %i", serverPort);
 				std::this_thread::sleep_for(std::chrono::milliseconds(500)); // Reduce Server listening socket open attempt frequency

--- a/Code/ServerApp/Source/NetImguiServer_RemoteClient.cpp
+++ b/Code/ServerApp/Source/NetImguiServer_RemoteClient.cpp
@@ -335,7 +335,7 @@ NetImguiImDrawData* Client::ConvertToImguiDrawData(const NetImgui::Internal::Cmd
 			pCommandDst[drawIdx].ElemCount			= pDrawSrc[drawIdx].mIdxCount;
 			pCommandDst[drawIdx].UserCallback		= nullptr;
 			pCommandDst[drawIdx].UserCallbackData	= nullptr;
-			pCommandDst[drawIdx].TextureId			= NetImgui::Internal::TextureCastFromID(pDrawSrc[drawIdx].mTextureId);
+			pCommandDst[drawIdx].TextureId			= ToImTextureID(pDrawSrc[drawIdx].mTextureId);
 		}
 	
 		pIndexDst		+= drawGroup.mIndiceCount;

--- a/Code/ServerApp/Source/NetImguiServer_RemoteClient.cpp
+++ b/Code/ServerApp/Source/NetImguiServer_RemoteClient.cpp
@@ -163,6 +163,7 @@ void Client::Uninitialize()
 	NetImgui::Internal::netImguiDeleteSafe(mpImguiDrawData);
 	NetImgui::Internal::netImguiDeleteSafe(mpFrameDrawPrev);
 	if (mpBGContext) {
+		mpBGContext->IO.BackendRendererUserData = nullptr;
 		ImGui::DestroyContext(mpBGContext);
 		mpBGContext	= nullptr;
 	}

--- a/Code/ServerApp/Source/NetImguiServer_UI.cpp
+++ b/Code/ServerApp/Source/NetImguiServer_UI.cpp
@@ -548,7 +548,7 @@ void DrawImguiContent_Clients()
 					ImGui::SetCursorPos(savedPos);
 
 					// Display Client Context
-					ImGui::Image(reinterpret_cast<ImTextureID>(client.mpHAL_AreaTexture), areaSize, ImVec2(0, HAL_API_RENDERTARGET_INVERT_Y ? 1 : 0), ImVec2(1, HAL_API_RENDERTARGET_INVERT_Y ? 0 : 1), tint_col, border_col);
+					ImGui::Image(ToImTextureID(client.mpHAL_AreaTexture), areaSize, ImVec2(0, HAL_API_RENDERTARGET_INVERT_Y ? 1 : 0), ImVec2(1, HAL_API_RENDERTARGET_INVERT_Y ? 0 : 1), tint_col, border_col);
 					if( ImGui::IsItemHovered() ){
 						ImGui::SetMouseCursor(client.mMouseCursor);
 					}

--- a/Code/ServerApp/Source/Sokol/NetImguiServer_App_Sokol.cpp
+++ b/Code/ServerApp/Source/Sokol/NetImguiServer_App_Sokol.cpp
@@ -70,7 +70,7 @@ void init() {
 
     bool ok = NetImguiServer::App::Startup(cmdArgs.c_str());
     IM_ASSERT(ok);
-    (VOID)ok;
+    (void)ok;
 
     // IMGUI Font texture init
     {


### PR DESCRIPTION
Hello,

In this pull request, I provide some simple fixes that I added when working on netImgui.

The commit messages should be sufficient to explain the content:

ea331b8 Add missing includes

5fa7511 Server init: correct fail message condition
There was a probable typo in the code

02a7d8a Rework ImTextureID casts: added ToImTextureID helper
ImTextureID could be anything (void *, uint64_t, uint_16t, GLuint, etc.)
so that using reinterpret_cast / static_cast can generate warnings or errors in some compilers,
depending on what the actual type of ImTextureID is. So, we resort to a C style double cast.

2279603 Use ImWChar for character (handle cases where we use ImWchar32)
(the compilation failed when using ImWchar32)

fa62011 NetImGui_Api / NewFrame: if (client.mbIsDrawing) return false
When a client wants to reconnect to the server, we can get to a situation where mbIsDrawing is true on the first frame. However, it will work on subsequent frames.

7c4fd3b Client::Uninitialize(): set mpBGContext->IO.BackendRendererUserData = nullptr before destroy
Otherwise we may end up in situations where ImGui::DestroyContext fails because it is not null.
This pointer was set to an external content, so it is safe to do so, and should not leak
