### PR TITLE
Add support for IMGUI_DISABLE

### DIFF
--- a/Code/Client/NetImgui_Api.h
+++ b/Code/Client/NetImgui_Api.h
@@ -59,7 +59,7 @@
 // When including this header, make sure imgui.h is included first 
 // (either always included in NetImgui_config.h or have it included after Imgui.h in your cpp)
 //-------------------------------------------------------------------------------------------------
-#if !defined(IMGUI_VERSION)
+#if !defined(IMGUI_VERSION) || defined(IMGUI_DISABLE)
 	#undef	NETIMGUI_ENABLED
 	#define NETIMGUI_ENABLED 					0
 #endif


### PR DESCRIPTION
Checking `IMGUI_VERSION` is not enough since it is always defined, so we need to additionally check `IMGUI_DISABLE`.