### PR TITLE
Avoid switching a built legacy font atlas to managed textures

### DIFF
--- a/Code/Client/Private/NetImgui_Client.cpp
+++ b/Code/Client/Private/NetImgui_Client.cpp
@@ -618,7 +618,14 @@ void ClientInfo::ContextOverride()
 
 #if NETIMGUI_IMGUI_TEXTURES_ENABLED
 		mFontSavedScaling 				= ImGui::GetStyle().FontScaleDpi;
-		newIO.BackendFlags				|= ImGuiBackendFlags_RendererHasTextures;
+		// Dear ImGui does not allow switching to managed textures after a legacy atlas build.
+		// NetImgui can still send the retained atlas pixels without changing the renderer flag.
+		const ImFontAtlas* pFontAtlas	= newIO.Fonts;
+		const bool bLegacyAtlasBuilt		= pFontAtlas && pFontAtlas->TexIsBuilt && !pFontAtlas->RendererHasTextures;
+		if( !bLegacyAtlasBuilt )
+		{
+			newIO.BackendFlags |= ImGuiBackendFlags_RendererHasTextures;
+		}
 		TextureTrackingUpdate(true); // Force resend all Dear Imgui managed textures
 #else
 		if( mFontCreationFunction != nullptr )


### PR DESCRIPTION
When NetImgui connects after a legacy renderer has built the font atlas, keep RendererHasTextures disabled. Dear ImGui does not allow this setting to change after the atlas is built. Continue sending the retained atlas pixels to the server so remote rendering still receives the font texture.